### PR TITLE
Saroup/none intent

### DIFF
--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -409,8 +409,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             int falsePositive,
             int falseNegative)
         {
-            var expectedUtterance = new LabeledUtterance(expected, null, null).WithProperty("speechFile", "speechFile");
-            var actualUtterance = new LabeledUtterance(actual, null, null);
+            var expectedUtterance = new LabeledUtterance(expected, string.Empty, null).WithProperty("speechFile", "speechFile");
+            var actualUtterance = new LabeledUtterance(actual, string.Empty, null);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });
@@ -468,8 +468,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var entityType = Guid.NewGuid().ToString();
             var expectedEntity = expected != null ? new[] { new Entity(entityType, null, expected, 0) } : null;
             var actualEntity = actual != null ? new[] { new Entity(entityType, null, actual, 0) } : null;
-            var expectedUtterance = new LabeledUtterance(null, null, expectedEntity);
-            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var expectedUtterance = new LabeledUtterance(null, string.Empty, expectedEntity);
+            var actualUtterance = new LabeledUtterance(null, string.Empty, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });
@@ -506,8 +506,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualJson = actual == null ? JValue.CreateNull() : (JValue)actual;
             var expectedEntity = new[] { new Entity(entityType, expectedJson, matchText, 0) };
             var actualEntity = new[] { new Entity(entityType, actualJson, matchText, 0) };
-            var expectedUtterance = new LabeledUtterance(null, null, expectedEntity);
-            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var expectedUtterance = new LabeledUtterance(null, string.Empty, expectedEntity);
+            var actualUtterance = new LabeledUtterance(null, string.Empty, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });
@@ -532,8 +532,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var matchText = Guid.NewGuid().ToString();
             var expectedEntity = new[] { new Entity(expectedEntityType, null, matchText, 0) };
             var actualEntity = new[] { new Entity(actualEntityType, null, matchText, 0) };
-            var expectedUtterance = new LabeledUtterance(null, null, expectedEntity);
-            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var expectedUtterance = new LabeledUtterance(null, string.Empty, expectedEntity);
+            var actualUtterance = new LabeledUtterance(null, string.Empty, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });
@@ -558,8 +558,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var matchText = Guid.NewGuid().ToString();
             var expectedEntity = new[] { new Entity(entityType, null, matchText, 0) };
             var actualEntity = new[] { new Entity(entityType, null, matchText, 0) };
-            var expectedUtterance = new LabeledUtterance(null, null, expectedEntity);
-            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var expectedUtterance = new LabeledUtterance(null, string.Empty, expectedEntity);
+            var actualUtterance = new LabeledUtterance(null, string.Empty, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });
@@ -569,8 +569,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void GetNLUCompareResultsExtractsIntentAndTextScore()
         {
-            var expectedUtterance = new LabeledUtterance(null, null, null).WithProperty("speechFile", "speechFile");
-            var actualUtterance = new LabeledUtterance(null, null, null).WithScore(0.5).WithTextScore(0.1);
+            var expectedUtterance = new LabeledUtterance(null, string.Empty, null).WithProperty("speechFile", "speechFile");
+            var actualUtterance = new LabeledUtterance(null, string.Empty, null).WithScore(0.5).WithTextScore(0.1);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });
@@ -589,8 +589,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var matchText = Guid.NewGuid().ToString();
             var expectedEntity = new[] { new Entity(entityType, null, matchText, 0) };
             var actualEntity = new[] { new Entity(entityType, null, matchText, 0).WithScore(0.5) };
-            var expectedUtterance = new LabeledUtterance(null, null, expectedEntity);
-            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var expectedUtterance = new LabeledUtterance(null, string.Empty, expectedEntity);
+            var actualUtterance = new LabeledUtterance(null, string.Empty, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });
@@ -605,8 +605,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var entityType = Guid.NewGuid().ToString();
             var matchText = Guid.NewGuid().ToString();
             var actualEntity = new[] { new Entity(entityType, null, matchText, 0).WithScore(0.5) };
-            var expectedUtterance = new LabeledUtterance(null, null, null);
-            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var expectedUtterance = new LabeledUtterance(null, string.Empty, null);
+            var actualUtterance = new LabeledUtterance(null, string.Empty, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -423,13 +423,13 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         [TestCase("foo", "foo", 1, 0, 0, 0)]
         [TestCase(null, null, 0, 1, 0, 0)]
-        [TestCase(null, "None", 0, 1, 0, 0)]
+        [TestCase(null, "None", 0, 0, 0, 1)]
         [TestCase("None", null, 0, 1, 0, 0)]
         [TestCase(null, "foo", 0, 0, 1, 0)]
-        [TestCase("None", "foo", 0, 0, 1, 0)]
+        [TestCase("None", "foo", 0, 0, 1, 1)]
         [TestCase("foo", "bar", 0, 0, 1, 1)]
         [TestCase("foo", null, 0, 0, 0, 1)]
-        [TestCase("foo", "None", 0, 0, 0, 1)]
+        [TestCase("foo", "None", 0, 0, 1, 1)]
         public static void GetNLUCompareResultsIntentStatistics(
             string expected,
             string actual,

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -27,31 +27,49 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void TestToIntentTestCaseExpectingNoneActualDayTime()
         {
+            var actual = "DayTime";
+            var expected = "None";
             var utterances = CreatePair(new[]
             {
-                new LabeledUtterance("FOO", "None", null),
-                new LabeledUtterance("FOO", "DayTime", null)
+                new LabeledUtterance("FOO", expected, null),
+                new LabeledUtterance("FOO", actual, null)
             });
 
             var tests = TestCaseSource.ToIntentTestCases(utterances);
-            tests.Count().Should().Be(1);
-            tests.Single().TestName.Should().MatchRegex(FalsePositiveIntentRegex);
-            tests.Single().ResultKind.Should().Be(ConfusionMatrixResultKind.FalsePositive);
+
+            tests.Count().Should().Be(2);
+            var actualFalsePositive = tests.FirstOrDefault(t => t.ResultKind == ConfusionMatrixResultKind.FalsePositive);
+            var actualFalseNegative = tests.FirstOrDefault(t => t.ResultKind == ConfusionMatrixResultKind.FalseNegative);
+            actualFalsePositive.Should().NotBeNull();
+            actualFalsePositive.TestName.Should().MatchRegex(FalsePositiveEntityRegex);
+            actualFalsePositive.Group.Should().Be(actual);
+            actualFalseNegative.Should().NotBeNull();
+            actualFalseNegative.TestName.Should().MatchRegex(FalseNegativeEntityRegex);
+            actualFalseNegative.Group.Should().Be(expected);
         }
 
         [Test]
         public static void TestToIntentTestCaseActualNoneExpectingDayTime()
         {
+            var actual = "None";
+            var expected = "Daytime";
             var utterances = CreatePair(new[]
             {
-                new LabeledUtterance("FOO", "DayTime", null),
-                new LabeledUtterance("FOO", "None", null)
+                new LabeledUtterance("FOO", expected, null),
+                new LabeledUtterance("FOO", actual, null)
             });
 
             var tests = TestCaseSource.ToIntentTestCases(utterances);
-            tests.Count().Should().Be(1);
-            tests.Single().TestName.Should().MatchRegex(FalseNegativeIntentRegex);
-            tests.Single().ResultKind.Should().Be(ConfusionMatrixResultKind.FalseNegative);
+
+            tests.Count().Should().Be(2);
+            var actualFalsePositive = tests.FirstOrDefault(t => t.ResultKind == ConfusionMatrixResultKind.FalsePositive);
+            var actualFalseNegative = tests.FirstOrDefault(t => t.ResultKind == ConfusionMatrixResultKind.FalseNegative);
+            actualFalsePositive.Should().NotBeNull();
+            actualFalsePositive.TestName.Should().MatchRegex(FalsePositiveEntityRegex);
+            actualFalsePositive.Group.Should().Be(actual);
+            actualFalseNegative.Should().NotBeNull();
+            actualFalseNegative.TestName.Should().MatchRegex(FalseNegativeEntityRegex);
+            actualFalseNegative.Group.Should().Be(expected);
         }
 
         [Test]
@@ -428,12 +446,12 @@ namespace NLU.DevOps.ModelPerformance.Tests
             compareResults.Statistics.Intent.TrueNegative.Should().Be(trueNegative);
             compareResults.Statistics.Intent.FalsePositive.Should().Be(falsePositive);
             compareResults.Statistics.Intent.FalseNegative.Should().Be(falseNegative);
-            if (expected != null && expected != "None")
+            if (expected != null)
             {
                 compareResults.Statistics.ByIntent[expected].TruePositive.Should().Be(truePositive);
                 compareResults.Statistics.ByIntent[expected].FalseNegative.Should().Be(falseNegative);
             }
-            else if (actual != null && actual != "None")
+            else if (actual != null)
             {
                 compareResults.Statistics.ByIntent[actual].FalsePositive.Should().Be(falsePositive);
             }

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -41,10 +41,10 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualFalsePositive = tests.FirstOrDefault(t => t.ResultKind == ConfusionMatrixResultKind.FalsePositive);
             var actualFalseNegative = tests.FirstOrDefault(t => t.ResultKind == ConfusionMatrixResultKind.FalseNegative);
             actualFalsePositive.Should().NotBeNull();
-            actualFalsePositive.TestName.Should().MatchRegex(FalsePositiveEntityRegex);
+            actualFalsePositive.TestName.Should().MatchRegex(FalsePositiveIntentRegex);
             actualFalsePositive.Group.Should().Be(actual);
             actualFalseNegative.Should().NotBeNull();
-            actualFalseNegative.TestName.Should().MatchRegex(FalseNegativeEntityRegex);
+            actualFalseNegative.TestName.Should().MatchRegex(FalseNegativeIntentRegex);
             actualFalseNegative.Group.Should().Be(expected);
         }
 
@@ -61,14 +61,15 @@ namespace NLU.DevOps.ModelPerformance.Tests
 
             var tests = TestCaseSource.ToIntentTestCases(utterances);
 
+            var testList = tests.ToList();
             tests.Count().Should().Be(2);
             var actualFalsePositive = tests.FirstOrDefault(t => t.ResultKind == ConfusionMatrixResultKind.FalsePositive);
             var actualFalseNegative = tests.FirstOrDefault(t => t.ResultKind == ConfusionMatrixResultKind.FalseNegative);
             actualFalsePositive.Should().NotBeNull();
-            actualFalsePositive.TestName.Should().MatchRegex(FalsePositiveEntityRegex);
+            actualFalsePositive.TestName.Should().MatchRegex(FalsePositiveIntentRegex);
             actualFalsePositive.Group.Should().Be(actual);
             actualFalseNegative.Should().NotBeNull();
-            actualFalseNegative.TestName.Should().MatchRegex(FalseNegativeEntityRegex);
+            actualFalseNegative.TestName.Should().MatchRegex(FalseNegativeIntentRegex);
             actualFalseNegative.Group.Should().Be(expected);
         }
 
@@ -439,9 +440,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var expectedUtterance = new LabeledUtterance(null, expected, null);
             var actualUtterance = new LabeledUtterance(null, actual, null);
+
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance });
+
             compareResults.Statistics.Intent.TruePositive.Should().Be(truePositive);
             compareResults.Statistics.Intent.TrueNegative.Should().Be(trueNegative);
             compareResults.Statistics.Intent.FalsePositive.Should().Be(falsePositive);

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -422,13 +422,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
 
         [Test]
         [TestCase("foo", "foo", 1, 0, 0, 0)]
-        [TestCase(null, null, 0, 1, 0, 0)]
-        [TestCase(null, "None", 0, 0, 0, 1)]
-        [TestCase("None", null, 0, 1, 0, 0)]
-        [TestCase(null, "foo", 0, 0, 1, 0)]
         [TestCase("None", "foo", 0, 0, 1, 1)]
         [TestCase("foo", "bar", 0, 0, 1, 1)]
-        [TestCase("foo", null, 0, 0, 0, 1)]
         [TestCase("foo", "None", 0, 0, 1, 1)]
         public static void GetNLUCompareResultsIntentStatistics(
             string expected,
@@ -449,15 +444,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
             compareResults.Statistics.Intent.TrueNegative.Should().Be(trueNegative);
             compareResults.Statistics.Intent.FalsePositive.Should().Be(falsePositive);
             compareResults.Statistics.Intent.FalseNegative.Should().Be(falseNegative);
-            if (expected != null)
-            {
-                compareResults.Statistics.ByIntent[expected].TruePositive.Should().Be(truePositive);
-                compareResults.Statistics.ByIntent[expected].FalseNegative.Should().Be(falseNegative);
-            }
-            else if (actual != null)
-            {
-                compareResults.Statistics.ByIntent[actual].FalsePositive.Should().Be(falsePositive);
-            }
+
+            compareResults.Statistics.ByIntent[expected].TruePositive.Should().Be(truePositive);
+            compareResults.Statistics.ByIntent[expected].FalseNegative.Should().Be(falseNegative);
+            compareResults.Statistics.ByIntent[actual].FalsePositive.Should().Be(falsePositive);
+
         }
 
         [Test]

--- a/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
@@ -71,7 +71,7 @@ namespace NLU.DevOps.ModelPerformance
                 return utterance.GetUtteranceId() ?? index.ToString(CultureInfo.InvariantCulture);
             }
 
-            var intents = expectedUtterances.Select(utterance => utterance.Intent).Distinct().ToList();
+            var intents = actualUtterances.Select(utterance => utterance.Intent).Distinct().ToList();
             var zippedUtterances = expectedUtterances
                 .Select((utterance, i) => new { Utterance = utterance, UtteranceId = getUtteranceId(utterance, i) })
                 .Zip(actualUtterances, (expected, actual) => new LabeledUtterancePair(expected.UtteranceId, expected.Utterance, actual))

--- a/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
@@ -71,12 +71,15 @@ namespace NLU.DevOps.ModelPerformance
                 return utterance.GetUtteranceId() ?? index.ToString(CultureInfo.InvariantCulture);
             }
 
+            var intents = expectedUtterances.Select(utterance => utterance.Intent).Distinct().ToList();
             var zippedUtterances = expectedUtterances
                 .Select((utterance, i) => new { Utterance = utterance, UtteranceId = getUtteranceId(utterance, i) })
                 .Zip(actualUtterances, (expected, actual) => new LabeledUtterancePair(expected.UtteranceId, expected.Utterance, actual))
                 .ToList();
 
-            var testCases = zippedUtterances.SelectMany(ToIntentTestCases)
+            var intentTestCases = zippedUtterances.SelectMany(utterance => ToIntentTestCases(utterance, intents));
+
+            var testCases = intentTestCases
                 .Concat(zippedUtterances.SelectMany(ToEntityTestCases))
                 .Concat(zippedUtterances.SelectMany(ToTextTestCases));
 
@@ -152,7 +155,7 @@ namespace NLU.DevOps.ModelPerformance
             }
         }
 
-        internal static IEnumerable<TestCase> ToIntentTestCases(LabeledUtterancePair pair)
+        internal static IEnumerable<TestCase> ToIntentTestCases(LabeledUtterancePair pair, List<string> intents)
         {
             var expectedUtterance = pair.Expected;
             var actualUtterance = pair.Actual;
@@ -162,25 +165,9 @@ namespace NLU.DevOps.ModelPerformance
             var expected = expectedUtterance.Intent;
             var actual = actualUtterance.Intent;
 
-            bool isNoneIntent(string intent)
+            if (expected == null || actual == null)
             {
-                return intent == null || intent == "None";
-            }
-
-            if (isNoneIntent(expected) && isNoneIntent(actual))
-            {
-                yield return TrueNegative(
-                    pair.UtteranceId,
-                    ComparisonTargetKind.Intent,
-                    expectedUtterance,
-                    actualUtterance,
-                    score,
-                    null,
-                    new[] { text },
-                    "Both intents are 'None'.",
-                    "Intent");
-
-                yield break;
+                throw new InvalidOperationException("Intent information is missing");
             }
 
             if (expected == actual)
@@ -195,11 +182,9 @@ namespace NLU.DevOps.ModelPerformance
                     new[] { expected, text },
                     "Utterances have matching intent.",
                     "Intent");
-
-                yield break;
             }
 
-            if (!isNoneIntent(expected))
+            if (expected != actual)
             {
                 yield return FalseNegative(
                     pair.UtteranceId,
@@ -211,10 +196,7 @@ namespace NLU.DevOps.ModelPerformance
                     new[] { expected, actual, text },
                     $"Expected intent '{expected}', actual intent '{actual}'.",
                     "Intent");
-            }
 
-            if (!isNoneIntent(actual))
-            {
                 yield return FalsePositive(
                     pair.UtteranceId,
                     ComparisonTargetKind.Intent,
@@ -225,6 +207,23 @@ namespace NLU.DevOps.ModelPerformance
                     new[] { expected, actual, text },
                     $"Expected intent '{expected}', actual intent '{actual}'.",
                     "Intent");
+            }
+
+            foreach (string intent in intents)
+            {
+                if (intent != actual && intent != expected)
+                {
+                    yield return TrueNegative(
+                        pair.UtteranceId,
+                        ComparisonTargetKind.Intent,
+                        expectedUtterance,
+                        actualUtterance,
+                        score,
+                        intent,
+                        new[] { text },
+                        $"The actual and expected are different from '{intent}'.",
+                        "Intent");
+                }
             }
         }
 


### PR DESCRIPTION
Addressing issue #249 https://github.com/microsoft/NLU.DevOps/issues/249  

Here is the suggested design for this change:
When no intents match an existing intent here is how each provider labels the intent:
1- LUIS would return a None intent
{
"text": "helloooo",
"intent": "None",
"entities": [],
"score": 0.9076262,
"textScore": 0.0,
"timestamp": "2020-01-28T11:20:42.8469612-05:00"
}
2. Aws Lex would return a **null ** intent
{
"dialogState": "ElicitIntent",
"intentName": null,
"message": "Sorry, can you please repeat that?",
...
}
3. Dialogflow would return a **default fallback ** intent
{
"text": "how are you today?",
"intent": "Default_Fallback_Intent",
"entities": []
},
Today's code does not support the compare command for Lex results since the format only supports "intentName" #252 will track the work to support Lex properly.
Current design for LUIS and DF is as follows:
null intents are not allowed. It probably means there is no "intent" entry in the JSON which makes the comparison void and we would throw an error when this happens.
None intent and default_fallback_intents are treated like any other intent
To calculate TP the actual and expected intents should match
When the actual intent is different from the expected we will record a FP for the actual and a FN for the expected.
For a given intent, if it doesn't match the actual or expected we then record a TN.
This behavior is matching the calculations that LUIS batch testing does.